### PR TITLE
package name is `bn.js`. Node.js on Linux it is case sensitive

### DIFF
--- a/packages/anonymous.js/src/client.js
+++ b/packages/anonymous.js/src/client.js
@@ -1,4 +1,4 @@
-const BN = require('BN.js');
+const BN = require('bn.js');
 
 const utils = require('./utils/utils.js');
 const Service = require('./utils/service.js');


### PR DESCRIPTION
The packages `bn.js` is lowercase and node.js on Linux is case sensitive. Probably you have either another package called BN.js which is uppercase or you got a link with BN.js in the node_modules